### PR TITLE
mark gem and its classes as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DEPRECATED - use rdf-vocab
+
+This gem is deprecated;  rdf-vocab gem (https://github.com/ruby-rdf/rdf-vocab, included in the linkeddata gem) now contains RDF::Vocab::IIIF and RDF::Vocab::SiocServices.
+
 # rdf-iiif
 
 [![Dependency Status](https://gemnasium.com/sul-dlss/rdf-iiif.svg)](https://gemnasium.com/sul-dlss/rdf-iiif) [![Gem Version](https://badge.fury.io/rb/rdf-iiif.svg)](http://badge.fury.io/rb/rdf-iiif)
@@ -9,7 +13,7 @@ Contains vocabularies to be used by RDF ruby gem https://github.com/ruby-rdf/rdf
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'rdf-iiif'
+gem 'rdf-vocab'  # (was rdf-iiif)
 ```
 
 And then execute:
@@ -18,19 +22,15 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install rdf-iiif
+    $ gem install rdf-vocab  # (was rdf-iiif)
 
 ## Usage
 
-    require 'rdf-iiif'
-    
-    RDF::IIIFPresentation.painting #=> RDF::URI("http://iiif.io/api/presentation/2#painting")
-    RDF::SIOC::Services.has_service #=> RDF::URI("http://rdfs.org/sioc/services#has_service")
+    require 'rdf/vocab'
 
-## Contributing
+    RDF::Vocab::IIIF.painting #=> RDF::URI("http://iiif.io/api/presentation/2#painting")
+    RDF::Vocab::SiocServices.has_service #=> RDF::URI("http://rdfs.org/sioc/services#has_service")
 
-1. Fork it ( https://github.com/[my-github-username]/rdf-iiif/fork )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request
+# DEPRECATED - use rdf-vocab
+
+This gem is deprecated;  rdf-vocab gem (https://github.com/ruby-rdf/rdf-vocab, included in the linkeddata gem) now contains RDF::Vocab::IIIF and RDF::Vocab::SiocServices.

--- a/lib/rdf/iiif/vocab.rb
+++ b/lib/rdf/iiif/vocab.rb
@@ -2,7 +2,16 @@
 # This file generated automatically using vocab-fetch from ../iiif-ontology-from-rob.owl and a little hand editing (added painting)
 require 'rdf'
 module RDF
-  class IIIFPresentation < RDF::StrictVocabulary("http://iiif.io/api/presentation/2#")
+  # deprecate IIIFPresentation
+  def self.const_missing(const_name)
+    super unless const_name == :IIIFPresentation
+    warn "DEPRECATION WARNING: the class RDF::IIIFPresentation is deprecated. Use RDF::Vocab::IIIF from https://github.com/ruby-rdf/rdf-vocab instead."
+    IIIFPresentationDeprecated
+  end
+
+  # @deprecated:  this class is deprecated in favor of RDF::Vocab::IIIF
+  #   from rdf-vocab gem
+  class IIIFPresentationDeprecated < RDF::StrictVocabulary("http://iiif.io/api/presentation/2#")
 
     # Class definitions
     term :AnnotationList,

--- a/lib/rdf/sioc_services_vocab.rb
+++ b/lib/rdf/sioc_services_vocab.rb
@@ -2,7 +2,16 @@
 # This file generated automatically using vocab-fetch from http://rdfs.org/sioc/services#
 require 'rdf'
 module RDF
-  class SIOC::Services < RDF::StrictVocabulary("http://rdfs.org/sioc/services#")
+  # deprecate SIOC::Services
+  def self.const_missing(const_name)
+    super unless const_name == :SIOC::Services
+    warn "DEPRECATION WARNING: the class RDF::SIOC::Services is deprecated. Use RDF::Vocab::SiocServices from https://github.com/ruby-rdf/rdf-vocab instead."
+    SIOC::ServicesDeprecated
+  end
+
+  # @deprecated:  this class is deprecated in favor of RDF::Vocab::SiocServices
+  #   from rdf-vocab gem
+  class SIOC::ServicesDeprecated < RDF::StrictVocabulary("http://rdfs.org/sioc/services#")
 
     # Class definitions
     term :Service,

--- a/rdf-iiif.gemspec
+++ b/rdf-iiif.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = RDF::IIIF::VERSION
   spec.authors       = ["Naomi Dushay"]
   spec.email         = ["ndushay@stanford.edu"]
-  spec.summary       = %q{IIIF (Presentation) vocabularies for RDF.rb}
-  spec.homepage      = ""
+  spec.summary       = %q{This gem deprecated in favor of rdf-vocab}
+  spec.homepage      = "https://github.com/sul-dlss/rdf-iiif"
   spec.license       = "Apache 2"
 
   spec.files         = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
these vocabs are in ruby-rdf/rdf-vocab as of release 0.8.2

@darrenleeweber 

connected to #1
